### PR TITLE
MANIFEST.in syntax fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-recursive-include *.py
+recursive-include circuit *.py
 include versioneer.py
 include README.md


### PR DESCRIPTION
This error prevented "setup.py sdist" from working, which prevented the module from being included in the virtualenvs.
