### PR TITLE
Fixes for __exit__() and a test

### DIFF
--- a/circuit/breaker.py
+++ b/circuit/breaker.py
@@ -106,6 +106,7 @@ class CircuitBreaker(object):
             self.success()
         elif exc_type in self.error_types:
             self.error(exc_val)
+            return True
         return False
 
 

--- a/circuit/test/test_breaker.py
+++ b/circuit/test/test_breaker.py
@@ -93,5 +93,5 @@ class CircuitBreakerTestCase(unittest.TestCase):
         def test():
             with self.breaker:
                 raise IOError("error")
-        self.assertRaises(IOError, test)
-        self.assertEquals(len(self.breaker.errors), 1)
+            self.assertRaises(IOError, test)
+            self.assertEquals(len(self.breaker.errors), 1)


### PR DESCRIPTION
I hope they are self explanatory. The original code allowed exceptions which had been set up to be trapped to leak out of the with block. The test failed because the assert alignments were out of scope of the contained method.