### PR TITLE
Added support for python3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
     - "2.6"
     - "2.7"
+    - "3.4"
 
 install:
     - pip install pep8 frosted

--- a/circuit/test/test_breaker.py
+++ b/circuit/test/test_breaker.py
@@ -164,7 +164,7 @@ class CircuitBreakerTestCase(unittest.TestCase):
         # 99th percentile value of count of failures
         failure_count = 0
         self.clock.advance(self.reset_timeout * 2)
-        for _ in xrange(0, 1000):
+        for _ in range(1000):
             try:
                 self.breaker.test()
                 self.breaker.open()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md') as f:
     long_description = f.read().strip()
 
 tests_require = [
-    'mockito==0.5.2',
+    'mockito==0.6.0',
     'Twisted>=10.2'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,13 @@ with open('README.md') as f:
 
 tests_require = [
     'mockito==0.6.0',
-    'Twisted>=10.2'
 ]
 
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')
+    tests_require.append('Twisted>=10.2,<15.5')  # py2.6 support was dropped in 15.5
+else:
+    tests_require.append('Twisted>=10.2')
 
 setup(name='python-circuit',
       version='0.1.8',


### PR DESCRIPTION
Hey,

I have added support for python 3... the required changes were minimal; only had to replace `xrange` with `range` (which was used only in tests anyway).

Also added a version constraint for Twisted, which dropped support for python 2.6 in version 15.5.